### PR TITLE
Use `CHeap` to allocate memory for `CGlyph`

### DIFF
--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -284,9 +284,6 @@ CGlyphMap::CGlyphMap(IGraphics *pGraphics, FT_Library FtLibrary)
 CGlyphMap::~CGlyphMap()
 {
 	FT_Stroker_Done(m_FtStroker);
-
-	for(int i = 0; i < m_Glyphs.size(); ++i)
-		delete m_Glyphs[i].m_pGlyph;
 }
 
 int CGlyphMap::GetCharGlyph(int Chr, FT_Face *pFace)
@@ -473,7 +470,7 @@ CGlyph *CGlyphMap::GetGlyph(int Chr, int FontSizeIndex, bool Render)
 	// couldn't find glyph, render a new one
 	if(r.empty())
 	{
-		Index.m_pGlyph = new CGlyph();
+		Index.m_pGlyph = (CGlyph *) m_Heap.Allocate(sizeof(CGlyph));
 		Index.m_pGlyph->m_Rendered = false;
 		Index.m_pGlyph->m_ID = Chr;
 		Index.m_pGlyph->m_FontSizeIndex = FontSizeIndex;

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -7,6 +7,8 @@
 #include <base/vmath.h>
 #include <engine/textrender.h>
 
+#include <engine/shared/memheap.h>
+
 // ft2 texture
 #include <ft2build.h>
 #include FT_FREETYPE_H
@@ -91,7 +93,7 @@ class CGlyphMap
 		void Init(int Index, int X, int Y, int Width, int Height);
 		ivec2 Add(int Width, int Height);
 	};
-
+	CHeap m_Heap;
 	IGraphics *m_pGraphics;
 	FT_Stroker m_FtStroker;
 	IGraphics::CTextureHandle m_aTextures[2];


### PR DESCRIPTION
title